### PR TITLE
fix(java): send launcher intents to the gRPC package name

### DIFF
--- a/java/app/src/main/java/eu/fiskaltrust/middleware/demo/MainActivity.java
+++ b/java/app/src/main/java/eu/fiskaltrust/middleware/demo/MainActivity.java
@@ -53,7 +53,7 @@ public class MainActivity extends AppCompatActivity {
   }
 
   public void startService(View view) {
-    ComponentName componentName = new ComponentName("eu.fiskaltrust.androidlauncher", "eu.fiskaltrust.androidlauncher.Start");
+    ComponentName componentName = new ComponentName("eu.fiskaltrust.androidlauncher.grpc", "eu.fiskaltrust.androidlauncher.grpc.Start");
 
     Intent intent = new Intent(Intent.ACTION_SEND);
     intent.setComponent(componentName);
@@ -66,7 +66,7 @@ public class MainActivity extends AppCompatActivity {
 
   public void stopService(View view) {
     Intent intent = new Intent(Intent.ACTION_SEND);
-    ComponentName componentName = new ComponentName("eu.fiskaltrust.androidlauncher", "eu.fiskaltrust.androidlauncher.Stop");
+    ComponentName componentName = new ComponentName("eu.fiskaltrust.androidlauncher.grpc", "eu.fiskaltrust.androidlauncher.grpc.Stop");
     intent.setComponent(componentName);
 
     sendBroadcast(intent);


### PR DESCRIPTION
## Problem

A customer reported that the Java demo crashes when they press **Send Echo Request**:

```
io.grpc.StatusRuntimeException: UNAVAILABLE
  at eu.fiskaltrust.middleware.demo.PosClient.echo(PosClient.java:30)
  at eu.fiskaltrust.middleware.demo.MainActivity.sendEchoRequest(MainActivity.java:76)
Caused by: java.net.ConnectException: failed to connect to localhost/127.0.0.1 (port 1400)
  ECONNREFUSED (Connection refused)
```

Nothing listens on port 1400, because the Middleware never started.

## Cause

The Android launcher was split into a gRPC application and an HTTP application. The component names changed:

| Launcher | Package | Start receiver |
|---|---|---|
| gRPC | `eu.fiskaltrust.androidlauncher.grpc` | `eu.fiskaltrust.androidlauncher.grpc.Start` |
| HTTP | `eu.fiskaltrust.androidlauncher.http` | `eu.fiskaltrust.androidlauncher.http.Start` |

The Java sample still targeted `eu.fiskaltrust.androidlauncher` / `eu.fiskaltrust.androidlauncher.Start`. That component no longer exists. Android drops such a broadcast and reports no error, so **Start service** did nothing.

The README, `xamarin/MainActivity.cs` and `maui/MainPage.xaml.cs` already use the new names. Only the Java sample kept the old ones.

## Change

Two lines in `MainActivity.java`. The start and the stop intent now target the gRPC launcher.

## Test

I could not build the sample locally, because `ANDROID_HOME` is not set and the project pins AGP 4.0.0 with `jcenter()`. Please build it in Android Studio and press **Start service**, then **Send Echo Request**.

## Out of scope

Two further defects exist in this repository. Tell me if you want separate pull requests.

1. `MainActivity` calls the blocking gRPC stubs on the UI thread with no `try`/`catch`. Any transport error terminates the application instead of showing a message.
2. `xamarin/POSSystemAPIIntentService.cs` and `maui/Platforms/Android/POSSystemAPIIntentService.cs` reference `eu.fiskaltrust.androidlauncher` and `eu.fiskaltrust.androidlauncher.PosSystemAPI`. The launcher exports no such component.
